### PR TITLE
Allow "ctrl" or "meta" modifier to improve experience on MacOS

### DIFF
--- a/scala/apps/dwd/src/Main.scala
+++ b/scala/apps/dwd/src/Main.scala
@@ -189,13 +189,15 @@ def bindings(
 
     // Zoom into box
     dblClickOnPart(Left, PartType(Seq(Box)))
-      .withMods(Ctrl)
+      //.withMods(Ctrl)
+      .withAltMods(Set(Ctrl), Set(Meta))
       .map(b => es.bgPlus(b))
       .flatMap(b => a.zoomIn(b, layout, entitySources)),
 
     // Zoom out of box
     dblClickOn(Left)
-      .withMods(Ctrl)
+      //.withMods(Ctrl)
+      .withAltMods(Set(Ctrl), Set(Meta))
       .flatMap(_ => a.zoomOut(layout, entitySources)),
 
     // Drag box
@@ -239,12 +241,14 @@ def bindings(
 
     // Undo
     keyDown("z")
-      .withMods(KeyModifier.Ctrl)
+      //.withMods(Ctrl)
+      .withAltMods(Set(Ctrl), Set(Meta))
       .andThen(IO(g.undo())),
 
     // Redo
     keyDown("Z")
-      .withMods(KeyModifier.Ctrl, KeyModifier.Shift)
+      //.withMods(Ctrl, Shift)
+      .withAltMods(Set(Ctrl, Shift), Set(Meta, Shift))
       .andThen(IO(g.redo())),
 
     // Print current state

--- a/scala/core/src/EditorState.scala
+++ b/scala/core/src/EditorState.scala
@@ -35,7 +35,6 @@ class EditorState(
     dispatcher: Dispatcher[IO],
     val eventQueue: Queue[IO, Event]
 ) {
-
   /** The main event bus for Semagrams. */
   val events = EventBus[Event]()
 
@@ -145,17 +144,17 @@ class EditorState(
       evt <- eventQueue.take
       actionOption = bindings.collectFirst(
         (
-            (bnd: Binding[A]) =>
-              bnd.modifiers match {
-                case Some(mods) => {
-                  if (keyboard.keyState.now().modifiers == mods) {
-                    bnd.selector.lift(evt)
-                  } else {
-                    None
-                  }
+          (bnd: Binding[A]) =>
+            bnd.predicate match {
+              case Some(p) => {
+                if (p(this, evt)) {
+                  bnd.selector.lift(evt)
+                } else {
+                  None
                 }
-                case None => bnd.selector.lift(evt)
               }
+              case None => bnd.selector.lift(evt)
+            }
         ).unlift
       )
       a <- actionOption match {

--- a/scala/core/src/api/package.scala
+++ b/scala/core/src/api/package.scala
@@ -12,6 +12,7 @@ package object api {
   export semagrams.{
     Actions,
     EditorState,
+    Event,
     Semagram,
     Sprite,
     MouseButton,


### PR DESCRIPTION
This pull request adds support for the meta modifier on MacOS. I added support for setting arbitrary predicates on bindings based on the current `EditorState` and `Event`, and kept specialized `withMods/withAltMods` APIs for backwards compatibility.